### PR TITLE
Enhance leave tracking and UI

### DIFF
--- a/lib/models/leave_type.dart
+++ b/lib/models/leave_type.dart
@@ -4,6 +4,7 @@ class LeaveType {
   String name;
   double count;
   Color color;
+  double used;
 
-  LeaveType({required this.name, required this.count, required this.color});
+  LeaveType({required this.name, required this.count, required this.color, this.used = 0.0});
 }

--- a/lib/pages/leave_page.dart
+++ b/lib/pages/leave_page.dart
@@ -42,6 +42,7 @@ class _LeavePageState extends State<LeavePage> {
     final names = prefs.getStringList('leaveNames');
     final counts = prefs.getStringList('leaveCounts');
     final colors = prefs.getStringList('leaveColors');
+    final usedValues = prefs.getStringList('leaveUsedValues');
 
     setState(() {
       if (names != null && counts != null && colors != null) {
@@ -51,6 +52,7 @@ class _LeavePageState extends State<LeavePage> {
             name: names[i],
             count: double.parse(counts[i]),
             color: Color(int.parse(colors[i])),
+            used: usedValues != null && i < usedValues.length ? double.parse(usedValues[i]) : 0.0,
           ),
         );
       }
@@ -64,6 +66,8 @@ class _LeavePageState extends State<LeavePage> {
         'leaveCounts', leaveTypes.map((leave) => leave.count.toStringAsFixed(2)).toList());
     await prefs.setStringList(
         'leaveColors', leaveTypes.map((leave) => leave.color.value.toString()).toList());
+    await prefs.setStringList(
+        'leaveUsedValues', leaveTypes.map((leave) => leave.used.toStringAsFixed(2)).toList());
   }
 
   @override
@@ -115,98 +119,32 @@ class _LeavePageState extends State<LeavePage> {
                         itemCount: leaveTypes.length,
                         itemBuilder: (context, index) {
                           final leave = leaveTypes[index];
-                          return Card(
-                            elevation: 2,
-                            margin: const EdgeInsets.symmetric(vertical: 8),
-                            child: Padding(
-                              padding: const EdgeInsets.all(16),
-                              child: Column(
-                                crossAxisAlignment: CrossAxisAlignment.start,
-                                children: [
-                                  Row(
-                                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                                    children: [
-                                      Expanded(
-                                        child: GestureDetector(
-                                          onTap: () =>
-                                              isEditing ? _showEditNameDialog(leave) : null,
-                                          child: Text(
-                                            leave.name,
-                                            style: TextStyle(
-                                              fontSize: 20,
-                                              fontWeight: FontWeight.bold,
-                                              decoration: isEditing
-                                                  ? TextDecoration.underline
-                                                  : TextDecoration.none,
-                                            ),
-                                          ),
-                                        ),
-                                      ),
-                                      if (isModifying)
-                                        IconButton(
-                                          icon: const Icon(Icons.delete, color: Colors.red),
-                                          onPressed: () {
-                                            setState(() {
-                                              leaveTypes.removeAt(index);
-                                            });
-                                            _saveLeaveData();
-                                          },
-                                        ),
-                                    ],
-                                  ),
-                                  const SizedBox(height: 12),
-                                  Container(
-                                    decoration: BoxDecoration(
-                                      color: leave.color.withOpacity(0.9),
-                                      borderRadius: BorderRadius.circular(12),
-                                    ),
-                                    child: Row(
-                                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                                      children: [
-                                        IconButton(
-                                          icon: const Icon(Icons.remove, color: Colors.white),
-                                          onPressed: () {
-                                            setState(() {
-                                              if (leave.count >= 0.25) {
-                                                leave.count = validateLeaveCount(leave.count - 1);
-                                                _saveLeaveData();
-                                              }
-                                            });
-                                          },
-                                        ),
-                                        GestureDetector(
-                                          onTap: () => _showInputDialog(leave),
-                                          child: Text(
-                                            leave.count
-                                                    .toString()
-                                                    .replaceAll(RegExp(r'.\d+$'), '')
-                                                    .length >
-                                                10
-                                                ? leave.count.toStringAsExponential(2)
-                                                : leave.count.toStringAsFixed(2),
-                                            style: const TextStyle(
-                                              fontSize: 32,
-                                              fontWeight: FontWeight.bold,
-                                              color: Colors.white,
-                                            ),
-                                          ),
-                                        ),
-                                        IconButton(
-                                          icon: const Icon(Icons.add, color: Colors.white),
-                                          onPressed: () {
-                                            setState(() {
-                                              leave.count =
-                                                  validateLeaveCount(leave.count + 0.5);
-                                              _saveLeaveData();
-                                            });
-                                          },
-                                        ),
-                                      ],
-                                    ),
-                                  ),
-                                ],
-                              ),
-                            ),
+                          return LeaveCard(
+                            leave: leave,
+                            isEditing: isEditing,
+                            isModifying: isModifying,
+                            onEditName: () => _showEditNameDialog(leave),
+                            onDelete: () {
+                              setState(() {
+                                leaveTypes.removeAt(index);
+                              });
+                              _saveLeaveData();
+                            },
+                            onEditTotalCount: () => _showInputDialog(leave),
+                            onIncrementUsed: () {
+                              setState(() {
+                                leave.used = validateLeaveCount(leave.used + 0.5);
+                                if (leave.used > leave.count) leave.used = leave.count;
+                                _saveLeaveData();
+                              });
+                            },
+                            onDecrementUsed: () {
+                              setState(() {
+                                leave.used = validateLeaveCount(leave.used - 0.5);
+                                if (leave.used < 0) leave.used = 0;
+                                _saveLeaveData();
+                              });
+                            },
                           );
                         },
                       ),
@@ -374,6 +312,116 @@ class _LeavePageState extends State<LeavePage> {
           ],
         );
       },
+    );
+  }
+}
+
+class LeaveCard extends StatelessWidget {
+  final LeaveType leave;
+  final bool isEditing;
+  final bool isModifying;
+  final VoidCallback onEditName;
+  final VoidCallback onDelete;
+  final VoidCallback onEditTotalCount;
+  final VoidCallback onIncrementUsed;
+  final VoidCallback onDecrementUsed;
+
+  const LeaveCard({
+    super.key,
+    required this.leave,
+    required this.isEditing,
+    required this.isModifying,
+    required this.onEditName,
+    required this.onDelete,
+    required this.onEditTotalCount,
+    required this.onIncrementUsed,
+    required this.onDecrementUsed,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      elevation: 2,
+      margin: const EdgeInsets.symmetric(vertical: 8),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Expanded(
+                  child: GestureDetector(
+                    onTap: isEditing ? onEditName : null,
+                    child: Text(
+                      leave.name,
+                      style: TextStyle(
+                        fontSize: 20,
+                        fontWeight: FontWeight.bold,
+                        decoration: isEditing ? TextDecoration.underline : TextDecoration.none,
+                      ),
+                    ),
+                  ),
+                ),
+                if (isModifying)
+                  IconButton(
+                    icon: const Icon(Icons.delete, color: Colors.red),
+                    onPressed: onDelete,
+                  ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Container(
+              decoration: BoxDecoration(
+                color: leave.color.withOpacity(0.9),
+                borderRadius: BorderRadius.circular(12),
+              ),
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Text(
+                    'Total: ${leave.count.toStringAsFixed(2)}',
+                    style: const TextStyle(fontSize: 16, color: Colors.white),
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.edit, color: Colors.white, size: 20),
+                    onPressed: onEditTotalCount,
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 8),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text('Used: ${leave.used.toStringAsFixed(2)}', style: const TextStyle(fontSize: 16)),
+                    Text('Remaining: ${(leave.count - leave.used).toStringAsFixed(2)}', style: const TextStyle(fontSize: 16)),
+                  ],
+                ),
+                Row(
+                  children: [
+                    IconButton(
+                      icon: const Icon(Icons.remove_circle_outline),
+                      color: leave.used <= 0 ? Colors.grey : Theme.of(context).colorScheme.primary,
+                      onPressed: leave.used <= 0 ? null : onDecrementUsed,
+                    ),
+                    IconButton(
+                      icon: const Icon(Icons.add_circle_outline),
+                      color: leave.used >= leave.count ? Colors.grey : Theme.of(context).colorScheme.primary,
+                      onPressed: leave.used >= leave.count ? null : onIncrementUsed,
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/test/models/leave_type_test.dart
+++ b/test/models/leave_type_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:leave_buddy/models/leave_type.dart'; // Adjust import path as needed
+
+void main() {
+  group('LeaveType Model', () {
+    test('Constructor initializes fields correctly with default used value', () {
+      final leaveType = LeaveType(name: 'Annual', count: 20, color: Colors.blue);
+      expect(leaveType.name, 'Annual');
+      expect(leaveType.count, 20);
+      expect(leaveType.color, Colors.blue);
+      expect(leaveType.used, 0.0); // Default value
+    });
+
+    test('Constructor initializes fields correctly with provided used value', () {
+      final leaveType = LeaveType(name: 'Sick', count: 10, color: Colors.red, used: 2.5);
+      expect(leaveType.name, 'Sick');
+      expect(leaveType.count, 10);
+      expect(leaveType.color, Colors.red);
+      expect(leaveType.used, 2.5);
+    });
+
+    test('Used value can be updated', () {
+      final leaveType = LeaveType(name: 'Vacation', count: 15, color: Colors.green);
+      expect(leaveType.used, 0.0);
+      leaveType.used = 5.0;
+      expect(leaveType.used, 5.0);
+    });
+  });
+}

--- a/test/pages/leave_page_test.dart
+++ b/test/pages/leave_page_test.dart
@@ -1,0 +1,78 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:leave_buddy/pages/leave_page.dart'; // Adjust import path
+
+// Temporary class to expose the method for testing
+class TestLeavePageState extends LeavePageState {
+  @override
+  Widget build(BuildContext context) {
+    // This build method won't be used in tests for validateLeaveCount
+    throw UnimplementedError();
+  }
+
+  // Expose the method for testing
+  double testValidateLeaveCount(double value) {
+    return super.validateLeaveCount(value);
+  }
+}
+
+void main() {
+  group('LeavePage - validateLeaveCount', () {
+    final pageState = TestLeavePageState();
+
+    test('should correctly validate whole numbers', () {
+      expect(pageState.testValidateLeaveCount(1.0), 1.0);
+      expect(pageState.testValidateLeaveCount(5.0), 5.0);
+    });
+
+    test('should correctly validate numbers ending in .00', () {
+      expect(pageState.testValidateLeaveCount(1.00), 1.0);
+      expect(pageState.testValidateLeaveCount(5.00), 5.0);
+    });
+
+    test('should correctly validate numbers ending in .25', () {
+      expect(pageState.testValidateLeaveCount(1.25), 1.25);
+      expect(pageState.testValidateLeaveCount(3.75), 3.75);
+    });
+
+    test('should correctly validate numbers ending in .5 or .50', () {
+      expect(pageState.testValidateLeaveCount(1.5), 1.5);
+      expect(pageState.testValidateLeaveCount(2.50), 2.5);
+    });
+
+    test('should correctly validate numbers ending in .75', () {
+      expect(pageState.testValidateLeaveCount(0.75), 0.75);
+      expect(pageState.testValidateLeaveCount(4.75), 4.75);
+    });
+
+    test('should round numbers to the nearest 0.25 increment', () {
+      // Rounds down
+      expect(pageState.testValidateLeaveCount(1.1), 1.0); // Rounds to 1.00
+      expect(pageState.testValidateLeaveCount(1.12), 1.0); // Rounds to 1.00, (1.12 * 4 = 4.48 -> round(4.48) = 4 -> 4/4 = 1.0)
+      expect(pageState.testValidateLeaveCount(2.3), 2.25); // Rounds to 2.25 (2.3 * 4 = 9.2 -> round(9.2) = 9 -> 9/4 = 2.25)
+      expect(pageState.testValidateLeaveCount(2.37), 2.25); // Rounds to 2.25 (2.37 * 4 = 9.48 -> round(9.48) = 9 -> 9/4 = 2.25)
+
+
+      // Rounds up
+      expect(pageState.testValidateLeaveCount(1.13), 1.25); // Rounds to 1.25 (1.13 * 4 = 4.52 -> round(4.52) = 5 -> 5/4 = 1.25)
+      expect(pageState.testValidateLeaveCount(1.20), 1.25); // Rounds to 1.25
+      expect(pageState.testValidateLeaveCount(2.4), 2.5);  // Rounds to 2.50 (2.4 * 4 = 9.6 -> round(9.6) = 10 -> 10/4 = 2.5)
+      expect(pageState.testValidateLeaveCount(2.6), 2.5); // Rounds to 2.50 (2.6 * 4 = 10.4 -> round(10.4) = 10 -> 10/4 = 2.5)
+      expect(pageState.testValidateLeaveCount(2.63), 2.75); // Rounds to 2.75 (2.63*4 = 10.52 -> round(10.52) = 11 -> 11/4 = 2.75)
+      expect(pageState.testValidateLeaveCount(3.88), 4.00); // Rounds to 4.00 (3.88*4 = 15.52 -> round(15.52) = 16 -> 16/4 = 4.00)
+      expect(pageState.testValidateLeaveCount(3.90), 4.00); // Rounds to 4.00
+    });
+
+    test('should handle zero correctly', () {
+      expect(pageState.testValidateLeaveCount(0.0), 0.0);
+    });
+
+    test('should handle negative numbers (rounding behavior)', () {
+      // The function's rounding should still apply
+      expect(pageState.testValidateLeaveCount(-1.0), -1.0);
+      expect(pageState.testValidateLeaveCount(-1.1), -1.0); // (-1.1 * 4 = -4.4 -> round(-4.4) = -4 -> -4/4 = -1.0)
+      expect(pageState.testValidateLeaveCount(-1.13), -1.25); // (-1.13 * 4 = -4.52 -> round(-4.52) = -5 -> -5/4 = -1.25)
+      expect(pageState.testValidateLeaveCount(-1.25), -1.25);
+      expect(pageState.testValidateLeaveCount(-1.4), -1.5); // (-1.4 * 4 = -5.6 -> round(-5.6) = -6 -> -6/4 = -1.5)
+    });
+  });
+}

--- a/test/widgets/leave_card_test.dart
+++ b/test/widgets/leave_card_test.dart
@@ -1,0 +1,201 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:leave_buddy/models/leave_type.dart'; // Adjust import
+import 'package:leave_buddy/pages/leave_page.dart'; // For LeaveCard, adjust import if moved
+
+// Mock callback functions
+class MockCallbacks {
+  int incrementCalled = 0;
+  int decrementCalled = 0;
+  int editNameCalled = 0;
+  int deleteCalled = 0;
+  int editTotalCountCalled = 0;
+
+  void onIncrementUsed() => incrementCalled++;
+  void onDecrementUsed() => decrementCalled++;
+  void onEditName() => editNameCalled++;
+  void onDelete() => deleteCalled++;
+  void onEditTotalCount() => editTotalCountCalled++;
+
+  void reset() {
+    incrementCalled = 0;
+    decrementCalled = 0;
+    editNameCalled = 0;
+    deleteCalled = 0;
+    editTotalCountCalled = 0;
+  }
+}
+
+void main() {
+  group('LeaveCard Widget Tests', () {
+    late LeaveType leave;
+    late MockCallbacks mockCallbacks;
+
+    setUp(() {
+      leave = LeaveType(name: 'Test Leave', count: 10.0, color: Colors.blue, used: 2.0);
+      mockCallbacks = MockCallbacks();
+    });
+
+    Widget buildTestableWidget(LeaveType currentLeave) {
+      return MaterialApp(
+        home: Scaffold(
+          body: LeaveCard(
+            leave: currentLeave,
+            isEditing: false,
+            isModifying: false,
+            onEditName: mockCallbacks.onEditName,
+            onDelete: mockCallbacks.onDelete,
+            onEditTotalCount: mockCallbacks.onEditTotalCount,
+            onIncrementUsed: mockCallbacks.onIncrementUsed,
+            onDecrementUsed: mockCallbacks.onDecrementUsed,
+          ),
+        ),
+      );
+    }
+
+    testWidgets('Displays leave name, total, used, and remaining correctly', (WidgetTester tester) async {
+      await tester.pumpWidget(buildTestableWidget(leave));
+
+      expect(find.text('Test Leave'), findsOneWidget);
+      expect(find.text('Total: 10.00'), findsOneWidget);
+      expect(find.text('Used: 2.00'), findsOneWidget);
+      expect(find.text('Remaining: 8.00'), findsOneWidget); // 10.0 - 2.0 = 8.0
+    });
+
+    testWidgets('Increment button calls onIncrementUsed callback', (WidgetTester tester) async {
+      await tester.pumpWidget(buildTestableWidget(leave));
+
+      await tester.tap(find.byIcon(Icons.add_circle_outline));
+      await tester.pump();
+
+      expect(mockCallbacks.incrementCalled, 1);
+      expect(mockCallbacks.decrementCalled, 0);
+    });
+
+    testWidgets('Decrement button calls onDecrementUsed callback', (WidgetTester tester) async {
+      await tester.pumpWidget(buildTestableWidget(leave));
+
+      await tester.tap(find.byIcon(Icons.remove_circle_outline));
+      await tester.pump();
+
+      expect(mockCallbacks.decrementCalled, 1);
+      expect(mockCallbacks.incrementCalled, 0);
+    });
+
+    testWidgets('Decrement button is disabled when used is 0', (WidgetTester tester) async {
+      leave.used = 0.0;
+      await tester.pumpWidget(buildTestableWidget(leave));
+
+      // Verify text for remaining
+      expect(find.text('Remaining: 10.00'), findsOneWidget);
+
+      // Find the IconButton for decrementing
+      final Finder decrementButtonFinder = find.widgetWithIcon(IconButton, Icons.remove_circle_outline);
+      final IconButton decrementButton = tester.widget(decrementButtonFinder);
+
+      // Check if onPressed is null, indicating it's disabled
+      expect(decrementButton.onPressed, isNull);
+
+      // Attempt to tap, should not call callback
+      await tester.tap(decrementButtonFinder);
+      await tester.pump();
+      expect(mockCallbacks.decrementCalled, 0);
+    });
+
+    testWidgets('Increment button is disabled when used equals count', (WidgetTester tester) async {
+      leave.used = 10.0;
+      await tester.pumpWidget(buildTestableWidget(leave));
+
+      // Verify text for remaining
+      expect(find.text('Remaining: 0.00'), findsOneWidget);
+
+      final Finder incrementButtonFinder = find.widgetWithIcon(IconButton, Icons.add_circle_outline);
+      final IconButton incrementButton = tester.widget(incrementButtonFinder);
+
+      expect(incrementButton.onPressed, isNull);
+
+      await tester.tap(incrementButtonFinder);
+      await tester.pump();
+      expect(mockCallbacks.incrementCalled, 0);
+    });
+
+     testWidgets('Increment button is enabled when used is less than count', (WidgetTester tester) async {
+      leave.used = 9.5; // Less than count (10.0)
+      await tester.pumpWidget(buildTestableWidget(leave));
+
+      final Finder incrementButtonFinder = find.widgetWithIcon(IconButton, Icons.add_circle_outline);
+      final IconButton incrementButton = tester.widget(incrementButtonFinder);
+
+      expect(incrementButton.onPressed, isNotNull);
+
+      await tester.tap(incrementButtonFinder);
+      await tester.pump();
+      expect(mockCallbacks.incrementCalled, 1);
+    });
+
+    testWidgets('Decrement button is enabled when used is greater than 0', (WidgetTester tester) async {
+      leave.used = 0.5; // Greater than 0
+      await tester.pumpWidget(buildTestableWidget(leave));
+
+      final Finder decrementButtonFinder = find.widgetWithIcon(IconButton, Icons.remove_circle_outline);
+      final IconButton decrementButton = tester.widget(decrementButtonFinder);
+
+      expect(decrementButton.onPressed, isNotNull);
+
+      await tester.tap(decrementButtonFinder);
+      await tester.pump();
+      expect(mockCallbacks.decrementCalled, 1);
+    });
+
+    testWidgets('Editing controls (name, total count) are testable if needed', (WidgetTester tester) async {
+      // Example for isEditing name (though LeaveCard itself doesn't show a dialog)
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: LeaveCard(
+            leave: leave,
+            isEditing: true, // Enable editing mode
+            isModifying: false,
+            onEditName: mockCallbacks.onEditName,
+            onDelete: mockCallbacks.onDelete,
+            onEditTotalCount: mockCallbacks.onEditTotalCount,
+            onIncrementUsed: mockCallbacks.onIncrementUsed,
+            onDecrementUsed: mockCallbacks.onDecrementUsed,
+          ),
+        ),
+      ));
+
+      await tester.tap(find.text('Test Leave'));
+      await tester.pump();
+      expect(mockCallbacks.editNameCalled, 1);
+
+      // Test for edit total count button
+      await tester.tap(find.byIcon(Icons.edit));
+      await tester.pump();
+      expect(mockCallbacks.editTotalCountCalled, 1);
+    });
+
+    testWidgets('Delete button calls onDelete callback when isModifying is true', (WidgetTester tester) async {
+        await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: LeaveCard(
+            leave: leave,
+            isEditing: true,
+            isModifying: true, // Enable modifying mode for delete icon
+            onEditName: mockCallbacks.onEditName,
+            onDelete: mockCallbacks.onDelete,
+            onEditTotalCount: mockCallbacks.onEditTotalCount,
+            onIncrementUsed: mockCallbacks.onIncrementUsed,
+            onDecrementUsed: mockCallbacks.onDecrementUsed,
+          ),
+        ),
+      ));
+
+      expect(find.byIcon(Icons.delete), findsOneWidget);
+      await tester.tap(find.byIcon(Icons.delete));
+      await tester.pump();
+      expect(mockCallbacks.deleteCalled, 1);
+    });
+
+
+  });
+}


### PR DESCRIPTION
This commit introduces several improvements to the Leave Buddy app:

- Added a `used` field to the `LeaveType` model to track used leave days.
- Updated the UI to display used leave and remaining balance for each leave type.
- Added buttons to increment and decrement the used leave count.
- Refactored `_LeavePageState` for better readability by extracting the `LeaveCard` widget.
- Added unit tests for the `LeaveType` model, `validateLeaveCount` method, and `LeaveCard` widget.